### PR TITLE
reuse actionName for audit result directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Set the working directory'
     default: ''
   actionName:
-    description: 'Set different action name. This is needet if the action is uset more than one in a repo.'
+    description: 'Set different action (and output directory) name. This is needed if the action is used more than once in a repo.'
     default: 'audit'
 runs:
   using: 'node12'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangro/actions-audit",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "description": "Run npm audit",
   "main": "lib/main.js",

--- a/src/audit/runAudit.ts
+++ b/src/audit/runAudit.ts
@@ -67,7 +67,7 @@ export async function runAudit(
   };
   try {
     const workingDirectory = core.getInput('workingDirectory');
-    const auditResultDirectory = core.getInput('actionName');
+    const auditResultDirectory = core.getInput('actionName') || 'audit';
     if (workingDirectory) {
       const [owner, repo] = context.repository.split('/');
       const execPath = path.join(

--- a/src/audit/runAudit.ts
+++ b/src/audit/runAudit.ts
@@ -46,7 +46,7 @@ const parseAudit = (audit: Audit): Result<Audit['metadata']> => {
     metadata,
     isOkay,
     shortText,
-    text,
+    text
   };
 };
 
@@ -62,11 +62,12 @@ export async function runAudit(
       },
       stderr: (data: Buffer) => {
         output += data.toString();
-      },
-    },
+      }
+    }
   };
   try {
     const workingDirectory = core.getInput('workingDirectory');
+    const auditResultDirectory = core.getInput('actionName');
     if (workingDirectory) {
       const [owner, repo] = context.repository.split('/');
       const execPath = path.join(
@@ -79,9 +80,9 @@ export async function runAudit(
     await exec('npm', ['audit', '--json', '--audit-level=moderate'], options);
     console.log('output: ', output);
     const auditResult: Audit = JSON.parse(output);
-    fs.mkdirSync('audit');
+    fs.mkdirSync(auditResultDirectory);
     fs.writeFileSync(
-      path.join('audit', 'index.html'),
+      path.join(auditResultDirectory, 'index.html'),
       generateAuditDetails(auditResult)
     );
     return parseAudit(auditResult);


### PR DESCRIPTION
momentan kracht es, wenn man audits für mehrere Verzeichnisse laufen lassen will (server + ui). Der `actionName` wird nur für den commit Status  context verwendet, jeder Aufruf versucht ein `audit` Verzeichnis zu erzeugen.

NOTE: alle Aufrufe, die `actionName` setzen, müssen ggfs angepasst werden, zumindest das folgende zip!

Fragen:
- wird der default `audit` automatisch gesetzt? In `main.ts` wird ans `getInput` noch ein `|| audit` angehängt
- wird das Verzeichnis noch anderweitig verwendet?