### PR TITLE
rarely happens, but..

### DIFF
--- a/src/audit/auditDetails.ts
+++ b/src/audit/auditDetails.ts
@@ -49,7 +49,7 @@ export const generateAuditDetails = (auditResult: Audit) => {
       <strong>Vulnerabilities</strong>
       <pre><code>${vulnerabilities}</code></pre>
       <ul>
-      ${Object.values(auditResult.advisories)
+      ${Object.values(auditResult.advisories || {})
         .sort(
           (findingA, findingB) => getSeverity(findingA) - getSeverity(findingB)
         )


### PR DESCRIPTION
wenn es tatsächlich mal **keine** advisories gibt, sollte das nicht in einem
```
error:  TypeError: Cannot convert undefined or null to object
    at Function.values (<anonymous>)
```
enden